### PR TITLE
DYN-2381 Exclude code block nodes from SetArgumentLacing

### DIFF
--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1126,8 +1126,10 @@ namespace Dynamo.ViewModels
 
         private void SetArgumentLacing(object parameter)
         {
-            var modelGuids = DynamoSelection.Instance.Selection.
-                OfType<NodeModel>().Select(n => n.GUID);
+            var modelGuids = DynamoSelection.Instance.Selection
+                .OfType<NodeModel>()
+                .Where(n => !(n is CodeBlockNodeModel))
+                .Select(n => n.GUID);
 
             if (!modelGuids.Any())
                 return;

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -113,7 +113,64 @@ namespace Dynamo.Tests
             AssertPreviewCount(nodeIds[1].ToString(), 2);
             AssertPreviewCount(nodeIds[2].ToString(), 2);
         }
+        
+        [Test]
+        public void VerifyLacingStrategyForCodeBlockNodes()
+        {
+            var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyCodeBlockNodes.dyn");
+            ViewModel.OpenCommand.Execute(openPath);
 
+            var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
+            workspace.RunSettings.RunType = RunType.Automatic;
+
+            Guid codeBlockNodeId = Guid.Parse("5a35517215434699afe122bc51aeff7d");
+            Guid otherNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
+            var codeBlockNode = workspace.NodeFromWorkspace(codeBlockNodeId);
+            var otherNode = workspace.NodeFromWorkspace(otherNodeId);
+
+            // Verify initial lacing state is Auto and nodes return correct number of results
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+
+            // Modify lacing strategy to Longest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Longest, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 10);
+
+            // Modify lacing strategy to Auto
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+
+            // Modify lacing strategy to CrossProduct
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.CrossProduct, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 10);
+
+            // Change lacing back to Shortest
+            ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
+            ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
+
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
+            Assert.AreEqual(LacingStrategy.Shortest, otherNode.ArgumentLacing);
+            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
+            AssertPreviewCount(otherNodeId.ToString(), 2);
+        }
+        
         [Test]
         public void AreGlobalLacingStrategiesInMenu()
         {

--- a/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
+++ b/test/DynamoCoreWpfTests/WorkspaceGeneralOperations.cs
@@ -115,60 +115,58 @@ namespace Dynamo.Tests
         }
         
         [Test]
-        public void VerifyLacingStrategyForCodeBlockNodes()
+        public void VerifyLacingStrategyCantBeChangedOnCodeBlocks()
         {
+            // Arrange
             var openPath = Path.Combine(TestDirectory, @"core\visualization\LacingStrategyCodeBlockNodes.dyn");
             ViewModel.OpenCommand.Execute(openPath);
-
             var workspace = ViewModel.Model.CurrentWorkspace as HomeWorkspaceModel;
-            workspace.RunSettings.RunType = RunType.Automatic;
-
             Guid codeBlockNodeId = Guid.Parse("5a35517215434699afe122bc51aeff7d");
-            Guid otherNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
+            Guid typicalNodeId = Guid.Parse("ab8afb7c1dfe4dd0994662f3306fc530");
             var codeBlockNode = workspace.NodeFromWorkspace(codeBlockNodeId);
-            var otherNode = workspace.NodeFromWorkspace(otherNodeId);
+            var typicalNode = workspace.NodeFromWorkspace(typicalNodeId);
 
             // Verify initial lacing state is Auto and nodes return correct number of results
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
+            var codeBlockNodeLacingStart = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingStart = typicalNode.ArgumentLacing;
+
+            // Act
 
             // Modify lacing strategy to Longest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Longest.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Longest, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 10);
+            var codeBlockNodeLacingLongest = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingLongest = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to Auto
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Auto.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Auto, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
+            var codeBlockNodeLacingAuto = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingAuto = typicalNode.ArgumentLacing;
 
             // Modify lacing strategy to CrossProduct
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.CrossProduct.ToString());
-
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.CrossProduct, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 10);
+            var codeBlockNodeLacingCross = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingCross = typicalNode.ArgumentLacing;
 
             // Change lacing back to Shortest
             ViewModel.CurrentSpaceViewModel.SelectAllCommand.Execute(null);
             ViewModel.CurrentSpaceViewModel.SetArgumentLacingCommand.Execute(LacingStrategy.Shortest.ToString());
+            var codeBlockNodeLacingShortest = codeBlockNode.ArgumentLacing;
+            var typicalNodeLacingShortest = typicalNode.ArgumentLacing;
 
-            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNode.ArgumentLacing);
-            Assert.AreEqual(LacingStrategy.Shortest, otherNode.ArgumentLacing);
-            AssertPreviewCount(codeBlockNodeId.ToString(), 2);
-            AssertPreviewCount(otherNodeId.ToString(), 2);
+            // Assert
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingStart);
+            Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingStart);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingLongest);
+            Assert.AreEqual(LacingStrategy.Longest, typicalNodeLacingLongest);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingAuto);
+            Assert.AreEqual(LacingStrategy.Auto, typicalNodeLacingAuto);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingCross);
+            Assert.AreEqual(LacingStrategy.CrossProduct, typicalNodeLacingCross);
+            Assert.AreEqual(LacingStrategy.Disabled, codeBlockNodeLacingShortest);
+            Assert.AreEqual(LacingStrategy.Shortest, typicalNodeLacingShortest);
         }
         
         [Test]

--- a/test/core/visualization/LacingStrategyCodeBlockNodes.dyn
+++ b/test/core/visualization/LacingStrategyCodeBlockNodes.dyn
@@ -1,0 +1,224 @@
+{
+  "Uuid": "3c9d0464-8643-5ffe-96e5-ab1769818209",
+  "IsCustomNode": false,
+  "Description": "",
+  "Name": "DYN-2381 CBN Lacing Multiplication",
+  "ElementResolver": {
+    "ResolutionMap": {}
+  },
+  "Inputs": [],
+  "Outputs": [],
+  "Nodes": [
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..2;",
+      "Id": "a96c9d6d6f494c34a6f8321ba7701caf",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "4e373052d56644dc93483c5a4138cdbb",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "1..10;",
+      "Id": "23c514fbf53c456882fcc34b2641b2ef",
+      "Inputs": [],
+      "Outputs": [
+        {
+          "Id": "d5d76f7e2f5946ed922f32b38298252a",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.ZeroTouch.DSFunction, DynamoCore",
+      "NodeType": "FunctionNode",
+      "FunctionSignature": "*@var[]..[],var[]..[]",
+      "Id": "ab8afb7c1dfe4dd0994662f3306fc530",
+      "Inputs": [
+        {
+          "Id": "4cc2d7cc1a4944a6aa1aef91cdefaa2d",
+          "Name": "x",
+          "Description": "x value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "a2e85ae1e0df4ea6be73aa31b753a30a",
+          "Name": "y",
+          "Description": "y value.\n\nvar[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "b299d917224744e380837fe6a584e389",
+          "Name": "var[]..[]",
+          "Description": "var[]..[]",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Auto",
+      "Description": "Multiplies x by y.\n\n* (x: var[]..[], y: var[]..[]): var[]..[]"
+    },
+    {
+      "ConcreteType": "Dynamo.Graph.Nodes.CodeBlockNodeModel, DynamoCore",
+      "NodeType": "CodeBlockNode",
+      "Code": "x*y;",
+      "Id": "5a35517215434699afe122bc51aeff7d",
+      "Inputs": [
+        {
+          "Id": "b15891aff6d44d0182145ccbace97e4b",
+          "Name": "x",
+          "Description": "x",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        },
+        {
+          "Id": "c926eafa523143eba0a5b186828cdc0f",
+          "Name": "y",
+          "Description": "y",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Outputs": [
+        {
+          "Id": "8547b6f7c4144781bc91c5c95bb90be2",
+          "Name": "",
+          "Description": "Value of expression at line 1",
+          "UsingDefaultValue": false,
+          "Level": 2,
+          "UseLevels": false,
+          "KeepListStructure": false
+        }
+      ],
+      "Replication": "Disabled",
+      "Description": "Allows for DesignScript code to be authored directly"
+    }
+  ],
+  "Connectors": [
+    {
+      "Start": "4e373052d56644dc93483c5a4138cdbb",
+      "End": "a2e85ae1e0df4ea6be73aa31b753a30a",
+      "Id": "8f470ec93f294f7fa4b67d8f7609f5e0"
+    },
+    {
+      "Start": "4e373052d56644dc93483c5a4138cdbb",
+      "End": "c926eafa523143eba0a5b186828cdc0f",
+      "Id": "f1f8c13bcb9b456cbf1b39fa466f7945"
+    },
+    {
+      "Start": "d5d76f7e2f5946ed922f32b38298252a",
+      "End": "4cc2d7cc1a4944a6aa1aef91cdefaa2d",
+      "Id": "27ab27ccd35a48bea33178bab8bdd808"
+    },
+    {
+      "Start": "d5d76f7e2f5946ed922f32b38298252a",
+      "End": "b15891aff6d44d0182145ccbace97e4b",
+      "Id": "1bb9252b158e44aebdb9ef3450687922"
+    }
+  ],
+  "Dependencies": [],
+  "NodeLibraryDependencies": [],
+  "Bindings": [],
+  "View": {
+    "Dynamo": {
+      "ScaleFactor": 1.0,
+      "HasRunWithoutCrash": true,
+      "IsVisibleInDynamoLibrary": true,
+      "Version": "2.8.0.2471",
+      "RunType": "Automatic",
+      "RunPeriod": "1000"
+    },
+    "Camera": {
+      "Name": "Background Preview",
+      "EyeX": -17.0,
+      "EyeY": 24.0,
+      "EyeZ": 50.0,
+      "LookX": 12.0,
+      "LookY": -13.0,
+      "LookZ": -58.0,
+      "UpX": 0.0,
+      "UpY": 1.0,
+      "UpZ": 0.0
+    },
+    "NodeViews": [
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "a96c9d6d6f494c34a6f8321ba7701caf",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 387.4,
+        "Y": 483.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "23c514fbf53c456882fcc34b2641b2ef",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 383.8,
+        "Y": 329.59999999999991
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "*",
+        "Id": "ab8afb7c1dfe4dd0994662f3306fc530",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 665.6,
+        "Y": 276.0
+      },
+      {
+        "ShowGeometry": true,
+        "Name": "Code Block",
+        "Id": "5a35517215434699afe122bc51aeff7d",
+        "IsSetAsInput": false,
+        "IsSetAsOutput": false,
+        "Excluded": false,
+        "X": 699.0,
+        "Y": 513.2
+      }
+    ],
+    "Annotations": [],
+    "X": -9.6000000000001364,
+    "Y": 2.3999999999999773,
+    "Zoom": 1.0
+  }
+}


### PR DESCRIPTION
### Purpose

JIRA: [DYN-2381](https://jira.autodesk.com/browse/DYN-2381)

Exclude Code Block Nodes when setting the lacing by selecting multiple nodes and right clicking on the canvas.

The previous behaviour did nothing but causes some visual anomalies and can be confusing to a user.

Previous Behaviour:

![DYN-2381-CBN-Lacing-Before](https://user-images.githubusercontent.com/193290/98557593-50286800-229c-11eb-8747-795ef350bdd9.gif)

Revised Behaviour

![DYN-2381-CBN-Lacing-Complete](https://user-images.githubusercontent.com/193290/98557603-53235880-229c-11eb-916d-7aea90942072.gif)

### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@SHKnudsen

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
