### PR TITLE
DYN-1078 Only remove inputs when count is greater than defaultNumInputs

### DIFF
--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using Dynamo.Core;
+using Dynamo.Graph.Nodes.ZeroTouch;
 using Dynamo.Graph.Workspaces;
 
 namespace Dynamo.Graph.Nodes
@@ -173,13 +174,17 @@ namespace Dynamo.Graph.Nodes
         /// </summary>
         public virtual void RemoveInputFromModel()
         {
-            var count = model.InPorts.Count;
-            if (count > 0)
+            int count = model.InPorts.Count;
+            bool countIsDefaultOrFewer = model is DSVarArgFunction dSVarArgFunction && count <= dSVarArgFunction.DefaultNumInputs;
+            if (count == 0 || countIsDefaultOrFewer)
             {
-                var port = model.InPorts[count - 1];
-                port.DestroyConnectors();
-                model.InPorts.Remove(port);
+                MarkNodeDirty();
+                return;
             }
+
+            var port = model.InPorts[count - 1];
+            port.DestroyConnectors();
+            model.InPorts.Remove(port);
 
             MarkNodeDirty();
         }

--- a/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
+++ b/src/DynamoCore/Graph/Nodes/VariableInputNode.cs
@@ -175,17 +175,13 @@ namespace Dynamo.Graph.Nodes
         public virtual void RemoveInputFromModel()
         {
             int count = model.InPorts.Count;
-            bool countIsDefaultOrFewer = model is DSVarArgFunction dSVarArgFunction && count <= dSVarArgFunction.DefaultNumInputs;
-            if (count == 0 || countIsDefaultOrFewer)
+            bool countIsGreaterThanDefault = model is DSVarArgFunction dSVarArgFunction && count > dSVarArgFunction.DefaultNumInputs;
+            if (count != 0 && countIsGreaterThanDefault)
             {
-                MarkNodeDirty();
-                return;
+                var port = model.InPorts[count - 1];
+                port.DestroyConnectors();
+                model.InPorts.Remove(port);
             }
-
-            var port = model.InPorts[count - 1];
-            port.DestroyConnectors();
-            model.InPorts.Remove(port);
-
             MarkNodeDirty();
         }
 


### PR DESCRIPTION
### Purpose

JIRA: [DYN-1078]( https://jira.autodesk.com/browse/DYN-1078)

Issue: https://github.com/DynamoDS/Dynamo/issues/8741

Prevent the user from being able to remove default ports using the `-` button on `DSVarArgFunction` nodes

Behaviour before:

![DYN-1078-Remove-Default-Inputs-Before-v2](https://user-images.githubusercontent.com/193290/98712937-dae19380-237e-11eb-90f2-2506422b04e4.gif)


Behaviour after:

![DYN-1078-Remove-Default-Inputs-Completed](https://user-images.githubusercontent.com/193290/98711472-ef249100-237c-11eb-850f-f86e702c829a.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
