### PR TITLE
DYN-2239 Set the UserAgent for HttpWebRequest

### DIFF
--- a/src/Libraries/CoreNodes/Web.cs
+++ b/src/Libraries/CoreNodes/Web.cs
@@ -28,6 +28,9 @@ namespace DSCore
             // Initialize the WebRequest.
             var myRequest = System.Net.WebRequest.Create(uriResult);
 
+            if (myRequest is System.Net.HttpWebRequest httpRequest)
+                httpRequest.UserAgent = "Dynamo";
+
             string responseFromServer;
 
             // Return the response. 

--- a/test/Libraries/CoreNodesTests/WebTests.cs
+++ b/test/Libraries/CoreNodesTests/WebTests.cs
@@ -28,5 +28,14 @@ namespace DSCoreNodesTests
         {
             Assert.Throws<ArgumentException>(() => Web.WebRequestByUrl(""));
         }
+
+        [Test]
+        [Category("UnitTests")]
+        public void WebRequest_GitHubAPI()
+        {
+            string url = "https://api.github.com/repos/DynamoDS/Dynamo/issues?page=0&state=closed&per_page=10";
+            string result = Web.WebRequestByUrl(url);
+            Assert.IsNotNullOrEmpty(result);
+        }
     }
 }


### PR DESCRIPTION
### Purpose

JIRA: [DYN-2239](https://jira.autodesk.com/browse/DYN-2239)

Set the `UserAgent` for `HTTPWebRequest` which is required by some APIs including GitHub: https://developer.github.com/v3/#user-agent-required

(FILL ME IN) This section describes why this PR is here. Usually it would include a reference 
to the tracking task that it is part or all of the solution for.

Behaviour before:
![DYN-2239-WebRequest-UserAgent-Before](https://user-images.githubusercontent.com/193290/98717585-2ac35900-2385-11eb-84d3-5ff848e4c5e4.jpg)

Behaviour after:
![DYN-2239-WebRequest-UserAgent-Completed](https://user-images.githubusercontent.com/193290/98717589-2bf48600-2385-11eb-8520-802ce3f57447.jpg)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [x] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
