### PR TITLE
DYN-1819 ExportExcel Write As String Option

### DIFF
--- a/src/Libraries/DSOffice/Excel.cs
+++ b/src/Libraries/DSOffice/Excel.cs
@@ -321,14 +321,15 @@ namespace DSOffice
         /// </param>
         /// <param name="data">Data to write to the spreadsheet.</param>
         /// <param name="overWrite"></param>
+        /// <param name="writeAsString">Toggle to switch between writing Excel file as strings.</param>
         /// <returns name="data">Data written to the spreadsheet.</returns>
         /// <search>office,excel,spreadsheet</search>
         [IsVisibleInDynamoLibrary(false)]
-        public static object[][] WriteToFile(string filePath, string sheetName, int startRow, int startCol, object[][] data, bool overWrite = false)
+        public static object[][] WriteToFile(string filePath, string sheetName, int startRow, int startCol, object[][] data, bool overWrite = false, bool writeAsString = false)
         {
             WorkBook wb = new WorkBook(filePath);
             WorkSheet ws = new WorkSheet(wb, sheetName, overWrite);
-            ws = ws.WriteData(startRow, startCol, data);
+            ws = ws.WriteData(startRow, startCol, data, writeAsString);
             return ws.Data;
         }
     }
@@ -522,8 +523,9 @@ namespace DSOffice
         /// <param name="startRow"></param>
         /// <param name="startColumn"></param>
         /// <param name="data"></param>
+        /// <param name="writeAsString"></param>
         /// <returns></returns>
-        internal WorkSheet WriteData(int startRow, int startColumn, object[][] data)
+        internal WorkSheet WriteData(int startRow, int startColumn, object[][] data, bool writeAsString = false)
         {
             startRow = Math.Max(0, startRow);
             startColumn = Math.Max(0, startColumn);
@@ -537,6 +539,8 @@ namespace DSOffice
             var c1 = (Range)ws.Cells[startRow + 1, startColumn + 1];
             var c2 = (Range)ws.Cells[startRow + numRows, startColumn + numColumns];
             var range = ws.Range[c1, c2];
+            if(writeAsString)
+                range.NumberFormat = "@";
             range.Value = rangeData;
 
             wb.Save();
@@ -831,11 +835,12 @@ namespace DSOffice
         /// </param>
         /// <param name="data">Data to write to the spreadsheet.</param>
         /// <param name="overWrite"></param>
+        /// <param name="writeAsString">Toggle to switch between writing Excel file as strings.</param>
         /// <returns name="data">Data written to the spreadsheet.</returns>
         /// <search>office,excel,spreadsheet</search>
-        public static object[][] ExportExcel(string filePath, string sheetName, int startRow, int startCol, object[][] data, bool overWrite = false)
+        public static object[][] ExportExcel(string filePath, string sheetName, int startRow, int startCol, object[][] data, bool overWrite = false, bool writeAsString = false)
         {
-            return Excel.WriteToFile(filePath, sheetName, startRow, startCol, data, overWrite);
+            return Excel.WriteToFile(filePath, sheetName, startRow, startCol, data, overWrite, writeAsString);
         }
     }
 }


### PR DESCRIPTION
### Purpose

JIRA: [DYN-1819](https://jira.autodesk.com/browse/DYN-1819)

Issues: https://github.com/DynamoDS/DynamoWishlist/issues/13

Added an additional `writeAsString` parameter to the `Data.ExportExcel` node. This parameter defaults to `false` ensuring the existing behaviour is preserved. When set to `true` the NumberFormat for the written range is set to `text`, therefore preserving the string rather than letting Excel automatically determine the format.

Behaviour before:
![DYN-1819-Export-Excel-Before](https://user-images.githubusercontent.com/193290/99093933-0eb0f900-25cb-11eb-8bc1-6a8deb84c406.gif)

Behaviour after `writeAsString: false`:
![DYN-1819-Export-Excel-After-False](https://user-images.githubusercontent.com/193290/99093989-1ffa0580-25cb-11eb-8781-a39a56882330.gif)

Behaviour after `writeAsString: true`:
![DYN-1819-Export-Excel-After-True](https://user-images.githubusercontent.com/193290/99093980-1cff1500-25cb-11eb-8b2d-4f0011bef56e.gif)


### Declarations

Check these if you believe they are true

- [x] The codebase is in a better state after this PR
- [x] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] All tests pass using the self-service CI.
- [x] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

(FILL ME IN) Reviewer 1  (If possible, assign the Reviewer for the PR)

(FILL ME IN, optional) Any additional notes to reviewers or testers.

### FYIs

(FILL ME IN, Optional) Names of anyone else you wish to be notified of
